### PR TITLE
Corrigido erro de chamada estática

### DIFF
--- a/source/PagSeguroLibrary/service/PagSeguroNotificationService.class.php
+++ b/source/PagSeguroLibrary/service/PagSeguroNotificationService.class.php
@@ -141,7 +141,7 @@ class PagSeguroNotificationService
      * @return bool|mixed|string
      * @throws PagSeguroServiceException
      */
-    private function searchReturn($connection, $parsers, $code)
+    private static function searchReturn($connection, $parsers, $code)
     {
         $httpStatus = new PagSeguroHttpStatus($connection->getStatus());
 


### PR DESCRIPTION
Ao utilizar o serviço de notificação o mesmo chama um método de forma estática no entanto o método não está assinado com static.

Non-static method PagSeguroNotificationService::searchReturn() should not be called statically [ROOT/vendor/pagseguro/php/source/PagSeguroLibrary/service/PagSeguroNotificationService.class.php, line 87]

Ver: https://cloud.githubusercontent.com/assets/2091739/5830977/e80dc17a-a10f-11e4-82a6-587a5921a200.png