### PR TITLE
Desenvolvimento

### DIFF
--- a/source/PagSeguroLibrary/PagSeguroLibrary.php
+++ b/source/PagSeguroLibrary/PagSeguroLibrary.php
@@ -45,9 +45,9 @@ class PagSeguroLibrary
 
     public static function init()
     {
-        require_once "loader" . DIRECTORY_SEPARATOR . "PagSeguroAutoLoader.class.php";
-        self::verifyDependencies();
         if (self::$library == null) {
+            require_once "loader" . DIRECTORY_SEPARATOR . "PagSeguroAutoLoader.class.php";
+            self::verifyDependencies();
             self::$library = new PagSeguroLibrary();
         }
         return self::$library;

--- a/source/PagSeguroLibrary/domain/PagSeguroPaymentRequest.class.php
+++ b/source/PagSeguroLibrary/domain/PagSeguroPaymentRequest.class.php
@@ -113,6 +113,14 @@ class PagSeguroPaymentRequest
     private $parameter;
 
     /***
+     * Class constructor to make sure the library was initialized.
+     */
+    public function __construct()
+    {
+        PagSeguroLibrary::init();
+    }
+
+    /***
      * @return PagSeguroSender the sender
      *
      * Party that will be sending the Uri to where the PagSeguro payment page should redirect the


### PR DESCRIPTION
 Devido a problemas com autoloading do composer, a classe PagSeguroLibrary não é inicializada, já que o `PagSeguroLibrary::init();` que está após a declaração da classe não é executada pelo composer. Portanto, quando classes e métodos que necessitam da classe incivilizada são usadas, exceções são lançadas.

 Por exemplo, no Laravel 5, `$paymentRequest = new \PagSeguroPaymentRequest();` funciona, porém `\PagSeguroConfig::getAccountCredentials();` lança uma exceção.

 Adicionei ao construtor do `PagSeguroPaymentRequest` uma chamada ao método `::init` para garantir que a biblioteca foi inicializada.
 Também modifiquei o método init para que, se a classe já tenha sido inicializada, nenhum processamento desnecessário seja feito.