### PR TITLE
Instanciar como objeto do  PagSeguroAddress

### DIFF
--- a/source/PagSeguroLibrary/domain/PagSeguroDirectPaymentRequest.class.php
+++ b/source/PagSeguroLibrary/domain/PagSeguroDirectPaymentRequest.class.php
@@ -672,7 +672,7 @@ class PagSeguroDirectPaymentRequest
             'country' => 'BRA'
             );
             
-            $this->billing->setAddress($billindAdress);
+            $this->billing->setAddress(new PagSeguroAddress($billindAdress));
         }
     }
 


### PR DESCRIPTION
O parâmetro do **setAddress** precisa ser um objeto da classe **PagSeguroAddress**.