### PR TITLE
Wrapper para o arquivo de configuração (corrigido)

### DIFF
--- a/source/PagSeguroLibrary/config/PagSeguroConfig.class.php
+++ b/source/PagSeguroLibrary/config/PagSeguroConfig.class.php
@@ -32,19 +32,18 @@ class PagSeguroConfig
     private static $config;
     private static $data;
 
-    const VARNAME = 'PagSeguroConfig';
-
     private function __construct()
     {
         define('ALLOW_PAGSEGURO_CONFIG', true);
 
-        require_once PagSeguroLibrary::getPath() .
-            DIRECTORY_SEPARATOR . "config" . DIRECTORY_SEPARATOR . "PagSeguroConfig.php";
-        $varName = self::VARNAME;
+        if(!class_exists('PagSeguroConfigWrapper'))
+            require_once PagSeguroLibrary::getPath() .
+                DIRECTORY_SEPARATOR . "config" . DIRECTORY_SEPARATOR . "PagSeguroConfig.php";
 
-        if (isset($$varName)) {
-            self::$data = $$varName;
-            unset($$varName);
+        $wrapper = new PagSeguroConfigWrapper();
+
+        if (method_exists($wrapper, 'getConfig')) {
+            self::$data = $wrapper->getConfig();
         } else {
             throw new Exception("Config is undefined.");
         }

--- a/source/PagSeguroLibrary/config/PagSeguroConfig.php
+++ b/source/PagSeguroLibrary/config/PagSeguroConfig.php
@@ -20,24 +20,32 @@
  *  @copyright 2007-2014 PagSeguro Internet Ltda.
  *  @license   http://www.apache.org/licenses/LICENSE-2.0
  */
+ 
+class PagSeguroConfigWrapper
+{
+    public static function getConfig()
+    {
+        $PagSeguroConfig = array();
 
-$PagSeguroConfig = array();
+        $PagSeguroConfig['environment'] = "production"; // production, sandbox
 
-$PagSeguroConfig['environment'] = "production"; // production, sandbox
+        $PagSeguroConfig['credentials'] = array();
+        $PagSeguroConfig['credentials']['email'] = "your_pagseguro_email";
+        $PagSeguroConfig['credentials']['token']['production'] = "your_production_pagseguro_token";
+        $PagSeguroConfig['credentials']['token']['sandbox'] = "your_sandbox_pagseguro_token";
+        $PagSeguroConfig['credentials']['appId']['production'] = "your__production_pagseguro_application_id";
+        $PagSeguroConfig['credentials']['appId']['sandbox'] = "your_sandbox_pagseguro_application_id";
+        $PagSeguroConfig['credentials']['appKey']['production'] = "your_production_application_key";
+        $PagSeguroConfig['credentials']['appKey']['sandbox'] = "your_sandbox_application_key";
 
-$PagSeguroConfig['credentials'] = array();
-$PagSeguroConfig['credentials']['email'] = "your_pagseguro_email";
-$PagSeguroConfig['credentials']['token']['production'] = "your_production_pagseguro_token";
-$PagSeguroConfig['credentials']['token']['sandbox'] = "your_sandbox_pagseguro_token";
-$PagSeguroConfig['credentials']['appId']['production'] = "your__production_pagseguro_application_id";
-$PagSeguroConfig['credentials']['appId']['sandbox'] = "your_sandbox_pagseguro_application_id";
-$PagSeguroConfig['credentials']['appKey']['production'] = "your_production_application_key";
-$PagSeguroConfig['credentials']['appKey']['sandbox'] = "your_sandbox_application_key";
+        $PagSeguroConfig['application'] = array();
+        $PagSeguroConfig['application']['charset'] = "UTF-8"; // UTF-8, ISO-8859-1
 
-$PagSeguroConfig['application'] = array();
-$PagSeguroConfig['application']['charset'] = "UTF-8"; // UTF-8, ISO-8859-1
+        $PagSeguroConfig['log'] = array();
+        $PagSeguroConfig['log']['active'] = false;
+        // Informe o path completo (relativo ao path da lib) para o arquivo, ex.: ../PagSeguroLibrary/logs.txt
+        $PagSeguroConfig['log']['fileLocation'] = "";
 
-$PagSeguroConfig['log'] = array();
-$PagSeguroConfig['log']['active'] = false;
-// Informe o path completo (relativo ao path da lib) para o arquivo, ex.: ../PagSeguroLibrary/logs.txt
-$PagSeguroConfig['log']['fileLocation'] = "";
+        return $PagSeguroConfig;
+    }
+}


### PR DESCRIPTION
A ideia é permitir que se configure a lib sem mexer na pasta vendor para os usuários do Composer, já que no modelo atual é impossível usar a biblioteca sem alterar arquivos que são revertidos sempre que se roda um `composer update`.

Dessa forma quem quiser configurar a lib sem mexer nos originais só define uma classe PagSeguroConfigWrapper antes de chamar o construtor da classe PagSeguroConfig, caso contrário ele lê o arquivo de configurações "padrão" para os que não tiverem problemas com isso.