### PR TITLE
Update PagSeguroTransactionSearchService.class.php

### DIFF
--- a/source/PagSeguroLibrary/service/PagSeguroTransactionSearchService.class.php
+++ b/source/PagSeguroLibrary/service/PagSeguroTransactionSearchService.class.php
@@ -339,7 +339,7 @@ class PagSeguroTransactionSearchService
      * @return bool|PagSeguroTransaction
      * @throws PagSeguroServiceException
      */
-    private function searchByCodeResult($connection, $code)
+    private static function searchByCodeResult($connection, $code)
     {
         $httpStatus = new PagSeguroHttpStatus($connection->getStatus());
 


### PR DESCRIPTION
Corrigindo erro: Non-static method PagSeguroTransactionSearchService::searchByCodeResult() should not be called statically