### PR TITLE
Correção de erro de chamada de método não estático.

### DIFF
--- a/source/PagSeguroLibrary/service/PagSeguroPreApprovalService.class.php
+++ b/source/PagSeguroLibrary/service/PagSeguroPreApprovalService.class.php
@@ -230,7 +230,7 @@ class PagSeguroPreApprovalService
      * @return null|PagSeguroParserData
      * @throws PagSeguroServiceException
      */
-    private function getResult($connection, $code = null)
+    private static function getResult($connection, $code = null)
     {
 
         $httpStatus = new PagSeguroHttpStatus($connection->getStatus());


### PR DESCRIPTION
A chamada do método getResult retornava um erro de tentativa de chamar um método não estático, logo foi adicionado o modificador static para permitir que o mesmo funcione em chamadas estáticas.