### PR TITLE
Atualização da classe PagSeguroAuthorizationRequest

### DIFF
--- a/source/PagSeguroLibrary/domain/PagSeguroAuthorizationRequest.class.php
+++ b/source/PagSeguroLibrary/domain/PagSeguroAuthorizationRequest.class.php
@@ -107,7 +107,7 @@ class PagSeguroAuthorizationRequest
      */
     public function setNotificationURL($notificationURL)
     {
-        $this->permissions = $notificationURL;
+        $this->notificationURL = $notificationURL;
     }
 
     /***


### PR DESCRIPTION
O método setNotificationURL está errado, está alterando a lista de permissões ao invés do notificationUrl.