### PR TITLE
Uncovered die() on the setParameter method

### DIFF
--- a/source/PagSeguroLibrary/domain/PagSeguroParameter.class.php
+++ b/source/PagSeguroLibrary/domain/PagSeguroParameter.class.php
@@ -43,10 +43,10 @@ class PagSeguroParameter
             if (!PagSeguroHelper::isEmpty($parameterItem->getValue())) {
                 $this->items[] = $parameterItem;
             } else {
-                die('requered parameterValue.');
+                throw new Exception("Parameter value is required for " . $parameterItem->getKey());
             }
         } else {
-            die('requered parameterKey.');
+            throw new Exception("Parameter key is required");
         }
     }
 


### PR DESCRIPTION
Metodo setParameter tinha um die() nao tratável no código, impossibilitando testes e trazendo resultados para o código que são impossíveis de tratar.
Ao mudar para um Throw Exception é possível tratar o erro e mostrar para o usuário uma mensagem amigável e tratar o comportamento do sistema, evitando inconsistencias.