### PR TITLE
Fix non-static method error on PagSeguroCancelService class.

### DIFF
--- a/source/PagSeguroLibrary/service/PagSeguroCancelService.class.php
+++ b/source/PagSeguroLibrary/service/PagSeguroCancelService.class.php
@@ -81,7 +81,7 @@ class PagSeguroCancelService
      * @return null|PagSeguroParserData
      * @throws PagSeguroServiceException
      */
-    private function getResult($connection)
+    private static function getResult($connection)
     {
         $httpStatus = new PagSeguroHttpStatus($connection->getStatus());
 


### PR DESCRIPTION
Fix the error: "Non-static method PagSeguroCancelService::getResult() should not be called statically"