### PR TITLE
Verificação adicional para evitar Warning

### DIFF
--- a/source/PagSeguroLibrary/domain/PagSeguroSender.class.php
+++ b/source/PagSeguroLibrary/domain/PagSeguroSender.class.php
@@ -168,7 +168,7 @@ class PagSeguroSender
     public function addDocument($type, $value)
     {
         if ($type && $value) {
-            if (count($this->documents) == 0) {
+            if (!isset($this->documents) || count($this->documents) == 0) {
                 $document = new PagSeguroSenderDocument($type, $value);
                 $this->documents[] = $document;
             }


### PR DESCRIPTION
Em desenvolvimento, usando php 7 estou recebendo a warning 
"Warning: count(): Parameter must be an array or an object that implements Countable in /vendor/pagseguro/php/source/PagSeguroLibrary/domain/PagSeguroSender.class.php on line 171"
quando a propriedade $documents ainda está vazia.